### PR TITLE
Fix prediction errors because of move type.

### DIFF
--- a/lua/entities/yava_chunk.lua
+++ b/lua/entities/yava_chunk.lua
@@ -30,7 +30,7 @@ function ENT:SetupCollisions(soup)
     
     self:PhysicsInit(SOLID_VPHYSICS)
     self:SetSolid(SOLID_VPHYSICS)    --- <= MIGHT only need this.
-    self:SetMoveType(MOVETYPE_VPHYSICS)
+    self:SetMoveType(MOVETYPE_NONE)
 
     self:SetCollisionGroup(COLLISION_GROUP_NONE)
 end


### PR DESCRIPTION
Since they don't ever move this should be MOVETYPE_NONE, this seems to fix the prediction errors when you initially jump on it.